### PR TITLE
Replaced go-ceph calls with CLI rbd calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ We attempt to adhere to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Update go-ceph import to use github.com/ceph/go-ceph instead of
   noahdesu/go-ceph
+- Recreate ceph connection and pool context for every operation (don't 
+  try to cache them)
 
 ## [0.2.2] - 2015-11-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We attempt to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- Update go-ceph import to use github.com/ceph/go-ceph instead of
+  noahdesu/go-ceph
 
 ## [0.2.2] - 2015-11-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ We attempt to adhere to [Semantic Versioning](http://semver.org/).
 - Try to open RBD Image without read-only option (no effect)
 - Try to use same client-id for every connection -- not possible in
   go-ceph
-- Adding --conf options to external rbd operations (having micro-osd
+- Adding --conf options to external rbd operations (was having micro-osd
   issues)
 
 ## [0.3.0] - 2015-11-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to project should be documented in this file.
 We attempt to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Added
+### Removed
+### Changed
+
+## [0.4.2] - 2016-03-16
+### Changed
+- Update logrotate config to restart instead of reload
+### Added 
+- Some new marathon-tester configs for running a test container in
+  Marathon/Mesos environment
+
 ## [0.4.1] - 2015-12-03
 ### Changed
 - Update systemd service unit to add --config /etc/ceph/ceph.conf 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@ All notable changes to project should be documented in this file.
 We attempt to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.4.0] - 2015-12-03
 ### Changed
-- Last ditch effort : Update all go-ceph functions to use CLI shell commands instead
+- Last ditch effort : Update all Plugin RBD functions to use CLI shell
+  commands instead of go-ceph library
 - Provide command line flag --go-ceph to use go-ceph lib, otherwise default
-  to sh CLI commands
+  now is shell CLI command via `rbd` binary
 
 ## [0.3.1] - 2015-11-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ We attempt to adhere to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### Changed
 
+## [0.5.0] - 2016-04-13
+### Changed
+- pulled latest from upstream yp-engineering/rbd-docker-plugin
+  - add new docker volume api support (Get, List)
+  - use ceph/go-ceph instead of noahdesu/go-ceph
+  - use docker/go-plugins-helpers/ instead of calavera/dkvolume
+
 ## [0.4.2] - 2016-03-16
 ### Changed
 - Update logrotate config to restart instead of reload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Change Log
+All notable changes to project should be documented in this file.
+We attempt to adhere to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Changed
+
+## [0.2.2] - 2015-11-19
+### Changed
+- Disable the reload operation in systemd service unit, having issues
+  with go-ceph lib and that operation (panics)
+- Update the Image Rename and Remove functions to use go-ceph lib
+  instead of shelling out to rbd binary
+- Update the tpkg scripts to start the service on installation
+
+## [0.2.1] - 2015-09-11
+### Added
+- Merged pull request with some RPM scripts for use in generic Redhat EL7 (Thanks Clement Laforet <sheepkiller@cotds.org>)
+
+## [0.2.0] - 2015-08-25
+### Changed
+- Added micro-osd script for testing Ceph locally
+
+## [0.1.9] - 2015-08-20
+### Changed
+- Added user ID and options to more shell rbd binary exec commands (Thanks Sébastien Han <seb@redhat.com>)
+- Moving version definition from tpkg.yml to version.go
+- Better blkid integration (Thanks Sébastien Han <seb@redhat.com>)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to project should be documented in this file.
 We attempt to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [0.4.1] - 2015-12-03
+### Changed
+- Update systemd service unit to add --config /etc/ceph/ceph.conf 
+- Force default config file in main.go to /etc/ceph/ceph.conf
 
 ## [0.4.0] - 2015-12-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ We attempt to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- Last ditch effort TODO: Update all go-ceph functions to use CLI shell commands instead
+
+## [0.3.1] - 2015-11-30
+### Changed
+- Try to open RBD Image without read-only option (no effect)
+- Try to use same client-id for every connection -- not possible in
+  go-ceph
+- Adding --conf options to external rbd operations (having micro-osd
+  issues)
+
+## [0.3.0] - 2015-11-25
+### Changed
 - Update go-ceph import to use github.com/ceph/go-ceph instead of
   noahdesu/go-ceph
 - Recreate ceph connection and pool context for every operation (don't 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ We attempt to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- Last ditch effort TODO: Update all go-ceph functions to use CLI shell commands instead
+- Last ditch effort : Update all go-ceph functions to use CLI shell commands instead
+- Provide command line flag --go-ceph to use go-ceph lib, otherwise default
+  to sh CLI commands
 
 ## [0.3.1] - 2015-11-30
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ test_from_container: make/test
 
 # build relocatable tpkg
 # TODO: repair PATHS at install to set TPKG_HOME (assumed /home/ops)
-package: version build test
+package: version build local_test
 	$(RM) -fr $(PACKAGE_BUILD)
 	mkdir -p $(PACKAGE_BIN_DIR) $(PACKAGE_INIT_DIR) $(PACKAGE_SYSTEMD_DIR) $(PACKAGE_LOG_CONFIG_DIR)
 	$(INSTALL) $(PACKAGE_SCRIPT_FILES) $(PACKAGE_BUILD)/.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ INSTALL?=install
 
 BINARY=rbd-docker-plugin
 PKG_SRC=main.go driver.go version.go
-PKG_SRC_TEST=$(PKG_SRC) driver_test.go
+PKG_SRC_TEST=$(PKG_SRC) driver_test.go unlock_test.go
 
 PACKAGE_BUILD=$(TMPDIR)/$(BINARY).tpkg.buildtmp
 
@@ -53,6 +53,7 @@ clean:
 uninstall:
 	@$(RM) -iv `which $(BINARY)`
 
+# FIXME: TODO: this micro-osd script leaves ceph-mds laying around -- fix it up
 test:
 	TMP_DIR=$$(mktemp -d) && \
 		./micro-osd.sh $$TMP_DIR && \

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,9 @@ test:
 
 
 # use existing ceph installation instead of micro-osd.sh - expecting CEPH_CONF to be set ...
+CEPH_CONF ?= /etc/ceph/ceph.conf
 local_test:
+	@echo "Using CEPH_CONF=$(CEPH_CONF)"
 	test -n "${CEPH_CONF}" && \
 		ceph -s && \
 		go test -v

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,13 @@ test:
 		go test -v && \
 		rm -rf $$TMP_DIR
 
+
+# use existing ceph installation instead of micro-osd.sh - expecting CEPH_CONF to be set ...
+local_test:
+	test -n "${CEPH_CONF}" && \
+		ceph -s && \
+		go test -v
+
 dist:
 	mkdir dist
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This plugin can create RBD images with XFS filesystem.
 - VolumeDriver golang framework: https://github.com/calavera/dkvolume
 - GlusterFS Example: https://github.com/calavera/docker-volume-glusterfs
 - KeyWhiz example: https://github.com/calavera/docker-volume-keywhiz
-- Ceph Rados, RBD golang lib: https://github.com/noahdesu/go-ceph
+- Ceph Rados, RBD golang lib: https://github.com/ceph/go-ceph
 
 Related Projects
 - https://github.com/AcalephStorage/docker-volume-ceph-rbd

--- a/driver.go
+++ b/driver.go
@@ -637,6 +637,7 @@ func (d *cephRBDVolumeDriver) createRBDImage(pool string, name string, size int,
 	//	"--image-features", strconv.Itoa(4),
 	_, err = sh(
 		"rbd", "create",
+		"--conf", d.config,
 		"--id", d.user,
 		"--pool", pool,
 		"--image-format", strconv.Itoa(2),
@@ -732,7 +733,8 @@ func (d *cephRBDVolumeDriver) lockImage(pool, imagename string) (string, error) 
 	rbdImage := rbd.GetImage(d.ioctx, imagename)
 
 	// open it (read-only)
-	err := rbdImage.Open(true)
+	//err := rbdImage.Open(true)
+	err := rbdImage.Open()
 	if err != nil {
 		log.Printf("ERROR: opening rbd image(%s): %s", imagename, err)
 		return "", err
@@ -771,7 +773,8 @@ func (d *cephRBDVolumeDriver) unlockImage(pool, imagename, locker string) error 
 	rbdImage := rbd.GetImage(d.ioctx, imagename)
 
 	// open it (read-only)
-	err := rbdImage.Open(true)
+	//err := rbdImage.Open(true)
+	err := rbdImage.Open()
 	if err != nil {
 		log.Printf("ERROR: opening rbd image(%s): %s", imagename, err)
 		return err
@@ -798,7 +801,7 @@ func (d *cephRBDVolumeDriver) renameRBDImage(pool, name, newname string) error {
 	// build image struct
 	rbdImage := rbd.GetImage(d.ioctx, name)
 
-	// remove the block device image
+	// rename the block device image
 	return rbdImage.Rename(newname)
 }
 
@@ -810,13 +813,13 @@ func (d *cephRBDVolumeDriver) renameRBDImage(pool, name, newname string) error {
 
 // mapImage will map the RBD Image to a kernel device
 func (d *cephRBDVolumeDriver) mapImage(pool, imagename string) (string, error) {
-	return sh("rbd", "map", "--id", d.user, "--pool", pool, imagename)
+	return sh("rbd", "--conf", d.config, "map", "--id", d.user, "--pool", pool, imagename)
 }
 
 // unmapImageDevice will release the mapped kernel device
 // TODO: does this operation even require a user --id ? I can unmap a device without or with a different id and rbd doesn't seem to care
 func (d *cephRBDVolumeDriver) unmapImageDevice(device string) error {
-	_, err := sh("rbd", "unmap", device)
+	_, err := sh("rbd", "--conf", d.config, "unmap", device)
 	return err
 }
 
@@ -827,6 +830,7 @@ func (d *cephRBDVolumeDriver) sh_removeRBDImage(pool, name string) error {
 	// remove the block device image
 	_, err := sh(
 		"rbd", "rm",
+		"--conf", d.config,
 		"--id", d.user,
 		"--pool", pool,
 		name,
@@ -843,6 +847,7 @@ func (d *cephRBDVolumeDriver) sh_renameRBDImage(pool, name, newname string) erro
 
 	_, err := sh(
 		"rbd", "rename",
+		"--conf", d.config,
 		"--id", d.user,
 		"--pool", pool,
 		name,

--- a/driver.go
+++ b/driver.go
@@ -476,7 +476,7 @@ func (d *cephRBDVolumeDriver) reload() {
 
 // connect builds up the ceph conn and default pool
 func (d *cephRBDVolumeDriver) connect() {
-	log.Println("INFO: connecting to Ceph and default pool context")
+	log.Println("INFO: connect() to Ceph")
 	d.m.Lock()
 	defer d.m.Unlock()
 
@@ -635,6 +635,8 @@ func (d *cephRBDVolumeDriver) createRBDImage(pool string, name string, size int,
 		msg := fmt.Sprintf("Unable to find mkfs for %s in PATH: %s", fstype, err)
 		return errors.New(msg)
 	}
+
+	// TODO: use the go-ceph Create(..) func for this
 
 	// create the block device image with format=2
 	//  should we enable all v2 image features?: +1: layering support +2: striping v2 support +4: exclusive locking support +8: object map support

--- a/driver.go
+++ b/driver.go
@@ -18,7 +18,7 @@ package main
 //
 // golang github code examples:
 // - https://github.com/docker/docker/blob/master/experimental/plugins_volume.md
-// - https://github.com/noahdesu/go-ceph
+// - https://github.com/ceph/go-ceph
 // - https://github.com/calavera/dkvolume
 // - https://github.com/calavera/docker-volume-glusterfs
 // - https://github.com/AcalephStorage/docker-volume-ceph-rbd
@@ -36,8 +36,8 @@ import (
 	"sync"
 
 	"github.com/calavera/dkvolume"
-	"github.com/noahdesu/go-ceph/rados"
-	"github.com/noahdesu/go-ceph/rbd"
+	"github.com/ceph/go-ceph/rados"
+	"github.com/ceph/go-ceph/rbd"
 )
 
 // TODO: switch to github.com/ceph/go-ceph ?
@@ -452,7 +452,7 @@ func (d cephRBDVolumeDriver) Unmount(r dkvolume.Request) dkvolume.Response {
 
 // shutdown closes the connection - maybe not needed unless we recreate conn?
 // more info:
-// - https://github.com/noahdesu/go-ceph/blob/master/rados/ioctx.go#L127
+// - https://github.com/ceph/go-ceph/blob/master/rados/ioctx.go#L127
 // - http://ceph.com/docs/master/rados/api/librados/
 func (d *cephRBDVolumeDriver) shutdown() {
 	log.Println("INFO: Ceph RBD Driver shutdown() called")

--- a/driver.go
+++ b/driver.go
@@ -399,7 +399,7 @@ func (d cephRBDVolumeDriver) Unmount(r dkvolume.Request) dkvolume.Response {
 	// check if it's in our mounts - we may not know about it if plugin was started late?
 	vol, found := d.volumes[mount]
 	if !found {
-		log.Println("WARN: Volume is not in known mounts: will attempt limited Unmount: " + name)
+		log.Printf("WARN: Volume is not in known mounts: will attempt limited Unmount: %s/%s", pool, name)
 		// set up a fake Volume with defaults ...
 		// - device is /dev/rbd/<pool>/<image> in newer ceph versions
 		// - assume we are the locker (will fail if locked from another host)

--- a/driver_test.go
+++ b/driver_test.go
@@ -38,11 +38,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestDriverReload(t *testing.T) {
-	t.Skip("This causes an error at driver.go:755 rbdImage.Open()")
-	testDriver.reload()
-}
-
 func TestLocalLockerCookie(t *testing.T) {
 	assert.NotEqual(t, "HOST_UNKNOWN", testDriver.localLockerCookie())
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -109,7 +109,7 @@ func TestSh_fail(t *testing.T) {
 
 // Helpers
 func formatError(name string, err error) string {
-	return fmt.Sprintf("ERROR calling %s: %s", name, err)
+	return fmt.Sprintf("ERROR calling %s: %q", name, err)
 }
 
 func parseImageAndHandleError(t *testing.T, name string) (string, string, int) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -43,7 +43,7 @@ func TestLocalLockerCookie(t *testing.T) {
 }
 
 func TestRbdImageExists_noName(t *testing.T) {
-	f_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, "")
+	f_bool, err := testDriver.rbdImageExists(testDriver.pool, "")
 	assert.Equal(t, false, f_bool, fmt.Sprintf("%s", err))
 }
 
@@ -51,7 +51,7 @@ func TestRbdImageExists_withName(t *testing.T) {
 	t.Skip("This fails for many reasons. Need to figure out how to do this in a container.")
 	err := testDriver.createRBDImage("rbd", "foo", 1, "xfs")
 	assert.Nil(t, err, formatError("createRBDImage", err))
-	t_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, "foo")
+	t_bool, err := testDriver.rbdImageExists(testDriver.pool, "foo")
 	assert.Equal(t, true, t_bool, formatError("rbdImageExists", err))
 }
 
@@ -59,7 +59,7 @@ func TestRbdImageExists_withName(t *testing.T) {
 func TestParseImagePoolNameSize_name(t *testing.T) {
 	pool, name, size := parseImageAndHandleError(t, "foo")
 
-	assert.Equal(t, testDriver.defaultPool, pool, "Pool should be same")
+	assert.Equal(t, testDriver.pool, pool, "Pool should be same")
 	assert.Equal(t, "foo", name, "Name should be same")
 	assert.Equal(t, *defaultImageSizeMB, size, "Size should be same")
 }
@@ -67,7 +67,7 @@ func TestParseImagePoolNameSize_name(t *testing.T) {
 func TestParseImagePoolNameSize_complexName(t *testing.T) {
 	pool, name, size := parseImageAndHandleError(t, "es-data1_v2.3")
 
-	assert.Equal(t, testDriver.defaultPool, pool, "Pool should be same")
+	assert.Equal(t, testDriver.pool, pool, "Pool should be same")
 	assert.Equal(t, "es-data1_v2.3", name, "Name should be same")
 	assert.Equal(t, *defaultImageSizeMB, size, "Size should be same")
 }
@@ -91,7 +91,7 @@ func TestParseImagePoolNameSize_withSize(t *testing.T) {
 func TestParseImagePoolNameSize_withPoolAndSize(t *testing.T) {
 	pool, name, size := parseImageAndHandleError(t, "foo@1024")
 
-	assert.Equal(t, testDriver.defaultPool, pool, "Pool should be same")
+	assert.Equal(t, testDriver.pool, pool, "Pool should be same")
 	assert.Equal(t, "foo", name, "Name should be same")
 	assert.Equal(t, 1024, size, "Size should be same")
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 		"rbd",
 		dkvolume.DefaultDockerRootDirectory,
 		cephConf,
+		false,
 	)
 	defer testDriver.shutdown()
 

--- a/logrotate.d/rbd-docker-plugin_logrotate
+++ b/logrotate.d/rbd-docker-plugin_logrotate
@@ -7,7 +7,7 @@
     notifempty
     # assuming centos 7.1 with systemd
     postrotate
-        systemctl reload rbd-docker-plugin.service > /dev/null 2>/dev/null || true
+        systemctl restart rbd-docker-plugin.service > /dev/null 2>/dev/null || true
     endscript
     notifempty
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 var (
 	// Plugin Option Flags
 	versionFlag        = flag.Bool("version", false, "Print version")
+	debugFlag          = flag.Bool("debug", false, "Debug output")
 	pluginName         = flag.String("name", "rbd", "Docker plugin name for use on --volume-driver option")
 	cephUser           = flag.String("user", "admin", "Ceph user")
 	cephConfigFile     = flag.String("config", "", "Ceph cluster config") // more likely to have config file pointing to cluster
@@ -119,7 +120,7 @@ func main() {
 
 // isDebugEnabled checks for RBD_DOCKER_PLUGIN_DEBUG environment variable
 func isDebugEnabled() bool {
-	return os.Getenv("RBD_DOCKER_PLUGIN_DEBUG") == "1"
+	return *debugFlag || os.Getenv("RBD_DOCKER_PLUGIN_DEBUG") == "1"
 }
 
 // setupLogging attempts to log to a file, otherwise stderr

--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ var (
 	debugFlag          = flag.Bool("debug", false, "Debug output")
 	pluginName         = flag.String("name", "rbd", "Docker plugin name for use on --volume-driver option")
 	cephUser           = flag.String("user", "admin", "Ceph user")
-	cephConfigFile     = flag.String("config", "", "Ceph cluster config") // more likely to have config file pointing to cluster
-	cephCluster        = flag.String("cluster", "", "Ceph cluster")       // less likely to run multiple clusters on same hardware
+	cephConfigFile     = flag.String("config", "/etc/ceph/ceph.conf", "Ceph cluster config") // more likely to have config file pointing to cluster
+	cephCluster        = flag.String("cluster", "", "Ceph cluster")                          // less likely to run multiple clusters on same hardware
 	defaultCephPool    = flag.String("pool", "rbd", "Default Ceph Pool for RBD operations")
 	pluginDir          = flag.String("plugins", "/run/docker/plugins", "Docker plugin directory for socket")
 	rootMountDir       = flag.String("mount", dkvolume.DefaultDockerRootDirectory, "Mount directory for volumes on host")

--- a/marathon-test/Dockerfile
+++ b/marathon-test/Dockerfile
@@ -1,0 +1,18 @@
+# Dockerfile to test the RBD Ceph Plugin via a marathon json job
+
+# container expects a mounted file, appends data to it and then exits after short sleep.
+
+# JSON file to lauch this job: marathon-test.json
+#    export MARATHON_HOST=localhost
+#    curl -X POST -H "Content-Type: application/json" \
+#        http://${MARATHON_HOST}:8080/v2/apps \
+#        -d@marathon-test.json
+
+FROM centos
+
+WORKDIR /root
+
+ENV RBD_TEST /mnt/foo/
+ADD run.sh /root/run.sh
+RUN chmod +x /root/run.sh
+CMD ["/root/run.sh"]

--- a/marathon-test/Makefile
+++ b/marathon-test/Makefile
@@ -1,0 +1,27 @@
+.PHONY: $(CONTAINER)
+
+SUDO ?=
+MARATHON_HOST ?= localhost
+MARATHON_PASS ?=
+
+# update this when you make changes
+APP_VERSION=0.1.1
+CONTAINER=rbd-marathon-test
+TAG?=latest
+REMOTE_NAME=$(CONTAINER):$(TAG)
+
+all: remote
+remote:	$(REMOTE_NAME)
+
+$(CONTAINER):
+	$(SUDO) docker build -t $(CONTAINER):$(APP_VERSION) .
+
+$(REMOTE_NAME): $(CONTAINER)
+	$(SUDO) docker tag -f $(CONTAINER):$(APP_VERSION) $(REMOTE_NAME):$(APP_VERSION)
+	$(SUDO) docker push $(REMOTE_NAME):$(APP_VERSION)
+
+deploy: $(REMOTE_NAME)
+	curl -X POST --user "admin:$(MARATHON_PASS)" -H "Content-Type: application/json" \
+	    http://$(MARATHON_HOST):8080/v2/apps \
+	    -d@marathon-test.json
+

--- a/marathon-test/marathon-test.json
+++ b/marathon-test/marathon-test.json
@@ -3,7 +3,8 @@
     "type": "DOCKER",
     "docker": {
       "network": "HOST",
-      "image": "centos:centos6.6",
+      "image": "rbd-marathon-test:latest",
+      "forcePullImage": true,
       "parameters": [
           { "key": "volume-driver", "value": "rbd" },
           { "key": "volume", "value": "foo:/mnt/foo:rw" }
@@ -11,10 +12,9 @@
     },
     "volumes": [ ]
   },
-  "cmd": "(while : ; do uptime; sleep 10 ; done) | tee /mnt/foo/uptime.log",
-  "id": "plugin-demo",
+  "id": "rbd-plugin-tester",
   "instances": 1,
-  "cpus": 0.5,
+  "cpus": 0.1,
   "mem": 256,
   "uris": []
 }

--- a/marathon-test/run.sh
+++ b/marathon-test/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# append a hello to a log file
+
+RBD_TEST=${RBD_TEST:-/mnt/foo}
+LOG_FILE=${RBD_TEST}/hello.log
+
+
+# don't make marathon churn too much ...
+SLEEP_TIME=${SLEEP_TIME:-300}
+
+# check for the file
+LOG_ERROR=0
+if [ ! -f $LOG_FILE ] ; then
+    echo "ERROR: unable to find log file: $LOG_FILE"
+    LOG_ERROR=1
+else
+    echo "NOTE: found the existing mounted log file: $LOG_FILE ==>"
+        cat $LOG_FILE
+    echo "----"
+fi
+
+# append our note
+echo "hello from $HOSTNAME on `date`" | tee -a $LOG_FILE
+
+# sleep a bit and exit
+echo -n "sleeping $SLEEP_TIME ... "
+sleep $SLEEP_TIME
+
+echo "goodbye from $HOSTNAME"
+
+if [ $LOG_ERROR != 0 ] ; then
+    exit $LOG_ERROR
+fi

--- a/micro-osd.sh
+++ b/micro-osd.sh
@@ -82,24 +82,7 @@ ceph osd crush add osd.${OSD_ID} 1 root=default host=localhost
 ceph-osd --id ${OSD_ID} --mkjournal --mkfs
 ceph-osd --id ${OSD_ID}
 
-# single mds
-MDS_DATA=${DIR}/mds.a
-mkdir ${MDS_DATA}
-
-cat >> $DIR/ceph.conf <<EOF
-[mds.a]
-mds data = ${MDS_DATA}
-mds log max segments = 2
-mds cache size = 10000
-host = localhost
-EOF
-
-ceph-authtool --create-keyring --gen-key --name=mds.a ${MDS_DATA}/keyring
-ceph -i ${MDS_DATA}/keyring auth add mds.a mon 'allow profile mds' osd 'allow *' mds 'allow'
-ceph osd pool create cephfs_data 8
-ceph osd pool create cephfs_metadata 8
-ceph fs new cephfs cephfs_metadata cephfs_data
-ceph-mds -i a
+# we don't need mds since we are not using cephfs - right?
 
 # check that it works
 rados --pool rbd put group /etc/group

--- a/micro-osd.sh
+++ b/micro-osd.sh
@@ -29,6 +29,7 @@ DIR=$1
 # get rid of process and directories leftovers
 pkill ceph-mon || true
 pkill ceph-osd || true
+pkill ceph-mds || true
 rm -fr $DIR
 
 # cluster wide parameters

--- a/systemd/rbd-docker-plugin.service
+++ b/systemd/rbd-docker-plugin.service
@@ -5,7 +5,7 @@ Wants=docker.service
 Before=docker.service
 
 [Service]
-ExecStart=/home/ops/bin/rbd-docker-plugin --create --plugins /run/docker/plugins
+ExecStart=/home/ops/bin/rbd-docker-plugin --create --config /etc/ceph/ceph.conf --plugins /run/docker/plugins
 Restart=on-failure
 # NOTE: this kill is not synchronous as recommended by systemd *shrug*
 # disabled for now - having odd plugin issues on reload need to debug further

--- a/systemd/rbd-docker-plugin.service
+++ b/systemd/rbd-docker-plugin.service
@@ -8,7 +8,8 @@ Before=docker.service
 ExecStart=/home/ops/bin/rbd-docker-plugin --create --plugins /run/docker/plugins
 Restart=on-failure
 # NOTE: this kill is not synchronous as recommended by systemd *shrug*
-ExecReload=/bin/kill -HUP $MAINPID
+# disabled for now - having odd plugin issues on reload need to debug further
+#ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/tpkg.yml
+++ b/tpkg.yml
@@ -1,17 +1,19 @@
 name: rbd-docker-plugin
 version: main.VERSION
-package_version: 1
+#package_version: 1
 maintainer: aavilla@yp.com
 description: A Docker VolumeDriver Plugin that can manipulate Ceph RBD images.
+# FIXME: not sure what happened but yp tpkg can no longer do this - some ruby error deep in bowels
+# /usr/lib/ruby/site_ruby/1.8/tpkg/os/redhat.rb:71:in `block in available_native_packages': available_native_packages error running yum (RuntimeError)
 # RPMS needed for Ceph .so libs
-dependencies:
-  - name: ceph
-    minimum_version: 0.94
-    native: true
-  - name: librados2
-    native: true
-  - name: librbd1
-    native: true
-  - name: docker-engine
-    minimum_version: 1.8
-    native: true
+#dependencies:
+#  - name: ceph
+#    minimum_version: 0.94
+#    native: true
+#  - name: librados2
+#    native: true
+#  - name: librbd1
+#    native: true
+#  - name: docker-engine
+#    minimum_version: 1.8
+#    native: true

--- a/tpkg.yml
+++ b/tpkg.yml
@@ -1,7 +1,7 @@
 name: rbd-docker-plugin
 version: main.VERSION
 #package_version: 1
-maintainer: aavilla@yp.com
+maintainer: dm9831@yp.com
 description: A Docker VolumeDriver Plugin that can manipulate Ceph RBD images.
 # FIXME: not sure what happened but yp tpkg can no longer do this - some ruby error deep in bowels
 # /usr/lib/ruby/site_ruby/1.8/tpkg/os/redhat.rb:71:in `block in available_native_packages': available_native_packages error running yum (RuntimeError)

--- a/unlock_test.go
+++ b/unlock_test.go
@@ -21,10 +21,6 @@ import (
 //"github.com/ceph/go-ceph/rbd"
 //"github.com/ceph/go-ceph/rados"
 
-// TODO: tests that need ceph
-// make fake cluster?
-// use dockerized container with ceph for tests?
-
 var (
 	//testDriver cephRBDVolumeDriver
 	testPool  = "rbd"

--- a/unlock_test.go
+++ b/unlock_test.go
@@ -6,39 +6,132 @@ package main
 // trying to write a small test to reproduce (un)locking issues
 
 import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	//"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/require"
 )
+
+//"github.com/ceph/go-ceph/rbd"
+//"github.com/ceph/go-ceph/rados"
 
 // TODO: tests that need ceph
 // make fake cluster?
 // use dockerized container with ceph for tests?
 
 var (
-//testDriver cephRBDVolumeDriver
+	//testDriver cephRBDVolumeDriver
+	testPool  = "rbd"
+	testImage = "rbd-test"
 )
 
-func TestRbdImageExists_withReconnect(t *testing.T) {
+func TestGoCephConnection(t *testing.T) {
 	var err error
-	var image = "foo2"
+
+	config := os.Getenv("CEPH_CONF")
 
 	// connect to default RBD pool
-	err = testDriver.connect("rbd")
+	err = testDriver.connect(testPool)
 	assert.Nil(t, err, err)
 	defer testDriver.shutdown()
 
-	// make a new image
-	err = testDriver.createRBDImage("rbd", image, 1, "xfs")
-	assert.Nil(t, err, formatError("createRBDImage", err))
+	// check if we need to make the image
+	imageAlreadyExists, err := testDriver.rbdImageExists(testDriver.defaultPool, testImage)
+	assert.Nil(t, err, fmt.Sprintf("Unable to check if image already exists: %s", err))
+
+	if imageAlreadyExists {
+		log.Printf("NOTE: image already exists: %s", testImage)
+	} else {
+		// make an image and format it  - do this via command line because ...
+		// to avoid issues with go-ceph and/or our implementation using it
+		_, err = test_sh("rbd", "--conf", config, "create", testImage, "--size", "1024")
+		assert.Nil(t, err, fmt.Sprintf("Unable to create new image: %s", err))
+
+		// FIXME: TODO: this is hanging for some reason ?? why --
+		testDevice, err := test_sh("sudo", "rbd", "--conf", config, "--pool", testPool, "map", testImage)
+		// try other shell ... never hung before ?
+		//testDevice, err := testDriver.mapImage(testPool, testImage)
+		assert.Nil(t, err, fmt.Sprintf("Unable to map image: %s", err))
+		assert.NotEqual(t, testDevice, "", fmt.Sprintf("Got an empty device name: '%s'", testDevice))
+
+		out, err := test_sh("sudo", "mkfs.xfs", testDevice)
+		log.Printf("DEBUG: mkfs output: ...\n%s", out)
+		assert.Nil(t, err, fmt.Sprintf("Unable to mkfs.xfs: %s", err))
+
+		// unmap device to get ready to use via go-ceph lib
+		_, err = test_sh("sudo", "rbd", "--conf", config, "--pool", testPool, "unmap", testDevice)
+		assert.Nil(t, err, fmt.Sprintf("Unable to unmap new fs image: %s", err))
+	}
+
+	//****************************************
+	// now try some go-ceph func
 
 	// check that it exists
-	t_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, image)
-	assert.Equal(t, true, t_bool, formatError("rbdImageExists", err))
+	t1_bool, err := testDriver.rbdImageExists(testPool, testImage)
+	assert.Equal(t, true, t1_bool, fmt.Sprintf("Unable to find image after create: %s", err))
 
-	// lock it
+	// try an unlock image - just in case ?
+	/**
+	err = testDriver.unlockImage(testPool, testImage, "")
+	if err != nil {
+		log.Printf("Expected failure to unlock image, but maybe for wrong reason: %s", err)
+	} else {
+		log.Printf("Expected failure didn't fail: image was already locked and we unlocked it.")
+	}
+	*/
 
-	// reconnect
+	// check that it exists (again)
+	t2_bool, err := testDriver.rbdImageExists(testPool, testImage)
+	assert.Equal(t, true, t2_bool, fmt.Sprintf("Unable to find image after create: %s", err))
+
+	// lock image
+	locker, err := testDriver.lockImage(testPool, testImage)
+	assert.Nil(t, err, fmt.Sprintf("Unable to get exclusive lock on image: %s", err))
+	assert.NotEqual(t, locker, "", fmt.Sprintf("Got an empty Locker name: '%s'", locker))
+
+	// can we list the lockers ? can we even get a valid open image handle?
+	/** big fat panic deep in go-ceph c-lib interaction
+	img := rbd.GetImage(testDriver.ioctx, testImage)
+	err = img.Open(true)
+	assert.Nil(t, err, fmt.Sprintf("Unable to open image via go-ceph: %s", err))
+
+	tag, lockers, err := img.ListLockers()
+	assert.Nil(t, err, fmt.Sprintf("Unable to list lockers for image: %s", err))
+	log.Printf("GetImage list lockers results: tag=%s, lockers=%q", tag, lockers)
+	*/
+
+	// shutdown / reconnect the ceph client
+	testDriver.shutdown()
+	err = testDriver.connect(testPool)
+	assert.Nil(t, err, fmt.Sprintf("Error reconnecting: %s", err))
 
 	// check that it exists again (e.g. in order to unlock it)
+	t3_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, testImage)
+	assert.Equal(t, true, t3_bool, fmt.Sprintf("Unable to find image after create: %s", err))
+
+	// unlock image
+	err = testDriver.unlockImage(testPool, testImage, locker)
+	assert.Nil(t, err, fmt.Sprintf("Unable to unlock image: %s", err))
+
+	// check that it exists again (e.g. because sanity)
+	t4_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, testImage)
+	assert.Equal(t, true, t4_bool, fmt.Sprintf("Unable to find image after create: %s", err))
+}
+
+func test_sh(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	log.Printf("DEBUG: sh CMD: %q", cmd)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		log.Printf("ERROR: %q: %s", err, stderr)
+	}
+	return strings.Trim(string(out), " \n"), err
 }

--- a/unlock_test.go
+++ b/unlock_test.go
@@ -1,0 +1,44 @@
+// Copyright 2015 YP LLC.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+package main
+
+// trying to write a small test to reproduce (un)locking issues
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: tests that need ceph
+// make fake cluster?
+// use dockerized container with ceph for tests?
+
+var (
+//testDriver cephRBDVolumeDriver
+)
+
+func TestRbdImageExists_withReconnect(t *testing.T) {
+	var err error
+	var image = "foo2"
+
+	// connect to default RBD pool
+	err = testDriver.connect("rbd")
+	assert.Nil(t, err, err)
+	defer testDriver.shutdown()
+
+	// make a new image
+	err = testDriver.createRBDImage("rbd", image, 1, "xfs")
+	assert.Nil(t, err, formatError("createRBDImage", err))
+
+	// check that it exists
+	t_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, image)
+	assert.Equal(t, true, t_bool, formatError("rbdImageExists", err))
+
+	// lock it
+
+	// reconnect
+
+	// check that it exists again (e.g. in order to unlock it)
+}

--- a/unlock_test.go
+++ b/unlock_test.go
@@ -38,7 +38,7 @@ func TestGoCephConnection(t *testing.T) {
 	defer testDriver.shutdown()
 
 	// check if we need to make the image
-	imageAlreadyExists, err := testDriver.rbdImageExists(testDriver.defaultPool, testImage)
+	imageAlreadyExists, err := testDriver.rbdImageExists(testPool, testImage)
 	assert.Nil(t, err, fmt.Sprintf("Unable to check if image already exists: %s", err))
 
 	if imageAlreadyExists {
@@ -108,7 +108,7 @@ func TestGoCephConnection(t *testing.T) {
 	assert.Nil(t, err, fmt.Sprintf("Error reconnecting: %s", err))
 
 	// check that it exists again (e.g. in order to unlock it)
-	t3_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, testImage)
+	t3_bool, err := testDriver.rbdImageExists(testPool, testImage)
 	assert.Equal(t, true, t3_bool, fmt.Sprintf("Unable to find image after create: %s", err))
 
 	// unlock image
@@ -116,8 +116,21 @@ func TestGoCephConnection(t *testing.T) {
 	assert.Nil(t, err, fmt.Sprintf("Unable to unlock image: %s", err))
 
 	// check that it exists again (e.g. because sanity)
-	t4_bool, err := testDriver.rbdImageExists(testDriver.defaultPool, testImage)
+	t4_bool, err := testDriver.rbdImageExists(testPool, testImage)
 	assert.Equal(t, true, t4_bool, fmt.Sprintf("Unable to find image after create: %s", err))
+}
+
+func TestShUnlockImage(t *testing.T) {
+	// lock it first ... ?
+	locker, err := testDriver.sh_lockImage(testPool, testImage)
+	if err != nil {
+		log.Printf("WARN: Unable to lock image in preparation for test: %s", err)
+		locker = testDriver.localLockerCookie()
+	}
+
+	// now unlock it
+	err = testDriver.sh_unlockImage(testPool, testImage, locker)
+	assert.Nil(t, err, fmt.Sprintf("Unable to unlock image using sh rbd: %s", err))
 }
 
 func test_sh(name string, args ...string) (string, error) {

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 // license that can be found in the LICENSE file.
 package main
 
-const VERSION = "0.4.0"
+const VERSION = "0.4.1"

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 // license that can be found in the LICENSE file.
 package main
 
-const VERSION = "0.1.9"
+const VERSION = "0.2.0"

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 // license that can be found in the LICENSE file.
 package main
 
-const VERSION = "0.3.1"
+const VERSION = "0.4.0"

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 // license that can be found in the LICENSE file.
 package main
 
-const VERSION = "0.4.2"
+const VERSION = "0.5.0"

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 // license that can be found in the LICENSE file.
 package main
 
-const VERSION = "0.2.2"
+const VERSION = "0.3.1"

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 // license that can be found in the LICENSE file.
 package main
 
-const VERSION = "0.2.0"
+const VERSION = "0.2.2"

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 // license that can be found in the LICENSE file.
 package main
 
-const VERSION = "0.4.1"
+const VERSION = "0.4.2"


### PR DESCRIPTION
Due to some issues with go-ceph and image locking in our environment (docker, mesos, etal), we had to switch to using only the command-line `rbd` utility provided by ceph install.  Because we need to GetImage after locking and possibly in another (newly started) plugin process (say, after a HUP from a logrotate we might close/reopen ceph connection and logfiles), which is not supported by go-ceph library.

Using the `rbd` command line has been more reliable with regards to locking/unlocking consistently.
