### PR TITLE
Try adding timeouts

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -29,8 +29,6 @@ package main
 // - https://github.com/AcalephStorage/docker-volume-ceph-rbd
 
 import (
-	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"log"
@@ -1162,37 +1160,4 @@ func (d *cephRBDVolumeDriver) rbdsh(pool, command string, args ...string) (strin
 		args = append([]string{"--pool", pool}, args...)
 	}
 	return sh("rbd", args...)
-}
-
-// sh is a simple os.exec Command tool, returns trimmed string output
-func sh(name string, args ...string) (string, error) {
-	cmd := exec.Command(name, args...)
-	if isDebugEnabled() {
-		log.Printf("DEBUG: sh CMD: %q", cmd)
-	}
-	// TODO: capture and output STDERR to logfile?
-	out, err := cmd.Output()
-	return strings.Trim(string(out), " \n"), err
-}
-
-// grepLines pulls out lines that match a string (no regex ... yet)
-func grepLines(data string, like string) []string {
-	var result = []string{}
-	if like == "" {
-		log.Printf("ERROR: unable to look for empty pattern")
-		return result
-	}
-	like_bytes := []byte(like)
-
-	scanner := bufio.NewScanner(strings.NewReader(data))
-	for scanner.Scan() {
-		if bytes.Contains(scanner.Bytes(), like_bytes) {
-			result = append(result, scanner.Text())
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		log.Printf("WARN: error scanning string for %s: %s", like, err)
-	}
-
-	return result
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -120,17 +120,6 @@ func TestSocketActivate(t *testing.T) {
 
 }
 
-func TestSh_success(t *testing.T) {
-	out, err := sh("ls")
-	assert.Nil(t, err, formatError("ls", err))
-	assert.Contains(t, out, "driver_test.go")
-}
-
-func TestSh_fail(t *testing.T) {
-	_, err := sh("false")
-	assert.NotNil(t, err, formatError("false", err))
-}
-
 // Helpers
 func formatError(name string, err error) string {
 	return fmt.Sprintf("ERROR calling %s: %q", name, err)

--- a/utils.go
+++ b/utils.go
@@ -38,6 +38,9 @@ func shWithTimeout(howLong time.Duration, name string, args ...string) (string, 
 	if howLong == 0 {
 		howLong = defaultShellTimeout
 	}
+	if isDebugEnabled() {
+		log.Printf("DEBUG: shWithTimeout: %v, %s, %v", howLong, name, args)
+	}
 
 	// fire up the goroutine for the actual shell command
 	go func() {

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var (
+	defaultShellTimeout = 2 * 60 * time.Second
+)
+
+// sh is a simple os.exec Command tool, returns trimmed string output
+func sh(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	if isDebugEnabled() {
+		log.Printf("DEBUG: sh CMD: %q", cmd)
+	}
+	// TODO: capture and output STDERR to logfile?
+	out, err := cmd.Output()
+	return strings.Trim(string(out), " \n"), err
+}
+
+// ShResult used for channel in timeout
+type ShResult struct {
+	Output string // STDOUT
+	Err    error  // go error, not STDERR
+}
+
+// shWithTimeout will run the Cmd and wait for the specified duration
+func shWithTimeout(howLong time.Duration, name string, args ...string) (string, error) {
+	// set up the results channel
+	resultsChan := make(chan ShResult, 1)
+	if howLong == 0 {
+		howLong = defaultShellTimeout
+	}
+
+	// fire up the goroutine for the actual shell command
+	go func() {
+		out, err := sh(name, args...)
+		resultsChan <- ShResult{Output: out, Err: err}
+	}()
+
+	select {
+	case res := <-resultsChan:
+		return res.Output, res.Err
+	case <-time.After(howLong):
+		return "", fmt.Errorf("Reached TIMEOUT on shell command")
+	}
+
+	return "", nil
+}
+
+// grepLines pulls out lines that match a string (no regex ... yet)
+func grepLines(data string, like string) []string {
+	var result = []string{}
+	if like == "" {
+		log.Printf("ERROR: unable to look for empty pattern")
+		return result
+	}
+	like_bytes := []byte(like)
+
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	for scanner.Scan() {
+		if bytes.Contains(scanner.Bytes(), like_bytes) {
+			result = append(result, scanner.Text())
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("WARN: error scanning string for %s: %s", like, err)
+	}
+
+	return result
+}

--- a/utils.go
+++ b/utils.go
@@ -31,13 +31,19 @@ type ShResult struct {
 	Err    error  // go error, not STDERR
 }
 
+// shWithDefaultTimeout will use the defaultShellTimeout so you dont have to pass one
+func shWithDefaultTimeout(name string, args ...string) (string, error) {
+	return shWithTimeout(defaultShellTimeout, name, args...)
+}
+
 // shWithTimeout will run the Cmd and wait for the specified duration
 func shWithTimeout(howLong time.Duration, name string, args ...string) (string, error) {
+	// duration can't be zero
+	if howLong <= 0 {
+		return "", fmt.Errorf("Timeout duration needs to be positive")
+	}
 	// set up the results channel
 	resultsChan := make(chan ShResult, 1)
-	if howLong == 0 {
-		howLong = defaultShellTimeout
-	}
 	if isDebugEnabled() {
 		log.Printf("DEBUG: shWithTimeout: %v, %s, %v", howLong, name, args)
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSh_success(t *testing.T) {
@@ -14,4 +16,43 @@ func TestSh_success(t *testing.T) {
 func TestSh_fail(t *testing.T) {
 	_, err := sh("false")
 	assert.NotNil(t, err, formatError("false", err))
+}
+
+func TestShWithTimeout_triggerDefaultTimeout(t *testing.T) {
+	// reset this global for the tests
+	defaultShellTimeout = 2 * time.Second
+	// sleep long enough to trigger timeout
+	sleepSecs := "4"
+	// pass 0 as our duration to use the default timeout
+	_, err := shWithTimeout(0, "sleep", sleepSecs)
+	assert.NotNil(t, err, "Expected to get error for timeout")
+	assert.Contains(t, err.Error(), "Reached TIMEOUT", "Expected 'Reached TIMEOUT' error")
+
+	// reset
+	defaultShellTimeout = 2 * 60 * time.Second
+}
+
+func TestShWithTimeout_cmdSucceeds(t *testing.T) {
+	// make command sleep a bit
+	sleepSecs := "1"
+
+	// make timeout a bit longer so we don't trigger it
+	timeout := 2 * time.Second
+
+	// pass timeout and cmd shorter than that
+	_, err := shWithTimeout(timeout, "sleep", sleepSecs)
+	assert.Nil(t, err, "Expected success for command, not timeout")
+}
+
+func TestShWithTimeout_cmdTimesOut(t *testing.T) {
+	// make timeout a bit shorter so we can trigger it
+	timeout := 1 * time.Second
+
+	// make command sleep a bit longer than that
+	sleepSecs := "4"
+
+	// pass our timeout and long sleep
+	_, err := shWithTimeout(timeout, "sleep", sleepSecs)
+	assert.NotNil(t, err, "Expected to get error for timeout")
+	assert.Contains(t, err.Error(), "Reached TIMEOUT", "Expected 'Reached TIMEOUT' error")
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSh_success(t *testing.T) {
+	out, err := sh("ls")
+	assert.Nil(t, err, formatError("ls", err))
+	assert.Contains(t, out, "driver_test.go")
+}
+
+func TestSh_fail(t *testing.T) {
+	_, err := sh("false")
+	assert.NotNil(t, err, formatError("false", err))
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -18,14 +18,7 @@ func TestSh_fail(t *testing.T) {
 	assert.NotNil(t, err, formatError("false", err))
 }
 
-func TestShWithTimeout_timeoutZeroFail(t *testing.T) {
-	// pass 0 as our duration to trigger the error
-	_, err := shWithTimeout(0, "sleep", "1")
-	assert.NotNil(t, err, "Expected to get error for duration")
-	assert.Contains(t, err.Error(), "duration needs to be positive", "Expected duration validation error")
-}
-
-func TestShWithTimeout_triggerDefaultTimeout(t *testing.T) {
+func TestShWithDefaultTimeout_triggerDefaultTimeout(t *testing.T) {
 	// reset this global for the tests
 	defaultShellTimeout = 2 * time.Second
 
@@ -39,6 +32,13 @@ func TestShWithTimeout_triggerDefaultTimeout(t *testing.T) {
 
 	// reset
 	defaultShellTimeout = 2 * 60 * time.Second
+}
+
+func TestShWithTimeout_timeoutZeroFail(t *testing.T) {
+	// pass 0 as our duration to trigger the error
+	_, err := shWithTimeout(0, "sleep", "1")
+	assert.NotNil(t, err, "Expected to get error for duration")
+	assert.Contains(t, err.Error(), "duration needs to be positive", "Expected duration validation error")
 }
 
 func TestShWithTimeout_cmdSucceeds(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -18,13 +18,22 @@ func TestSh_fail(t *testing.T) {
 	assert.NotNil(t, err, formatError("false", err))
 }
 
+func TestShWithTimeout_timeoutZeroFail(t *testing.T) {
+	// pass 0 as our duration to trigger the error
+	_, err := shWithTimeout(0, "sleep", "1")
+	assert.NotNil(t, err, "Expected to get error for duration")
+	assert.Contains(t, err.Error(), "duration needs to be positive", "Expected duration validation error")
+}
+
 func TestShWithTimeout_triggerDefaultTimeout(t *testing.T) {
 	// reset this global for the tests
 	defaultShellTimeout = 2 * time.Second
+
 	// sleep long enough to trigger timeout
 	sleepSecs := "4"
-	// pass 0 as our duration to use the default timeout
-	_, err := shWithTimeout(0, "sleep", sleepSecs)
+
+	// use the default timeout - we want to trigger it
+	_, err := shWithDefaultTimeout("sleep", sleepSecs)
 	assert.NotNil(t, err, "Expected to get error for timeout")
 	assert.Contains(t, err.Error(), "Reached TIMEOUT", "Expected 'Reached TIMEOUT' error")
 


### PR DESCRIPTION
My attempt at adding some timeout capabilities to the external shell commands.

Having some issues sometimes where a mount may hang (possibly XFS disk issues) and this seems to cause the RBD plugin to hang which then seems to cause docker itself to hang.  If the goroutined process still hangs, I suppose it will still be hanging, but we might possibly regain control of the thread?

Still testing this in different failure scenarios - not sure if it actually fixes the docker daemon hanging issue as well. 
