### PR TITLE
Option to enable lock override and blacklisting of old lock holder

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -62,6 +62,12 @@ type Volume struct {
 	pool   string
 }
 
+type Lock struct {
+	locker  string
+	id      string
+	address string
+}
+
 // TODO: finish modularizing and split out go-ceph and shell-cli implementations
 //
 // in progress: interface to abstract the ceph operations - either go-ceph lib or sh cli commands
@@ -376,8 +382,39 @@ func (d cephRBDVolumeDriver) Mount(r dkvolume.MountRequest) dkvolume.Response {
 	// attempt to lock
 	locker, err := d.lockImage(pool, name)
 	if err != nil {
-		log.Printf("ERROR: locking RBD Image(%s): %s", name, err)
-		return dkvolume.Response{Err: "Unable to get Exclusive Lock"}
+		if *canOverrideLock {
+			// Image is locked, we are going to override the lock
+
+			lockers, err := d.sh_getImageLocks(pool, name)
+			if err != nil {
+				log.Printf("ERROR: locking RBD Image(%s): %s", name, err)
+				return dkvolume.Response{Err: "Unable to get Exclusive Lock"}
+			}
+
+			if len(lockers) != 1 {
+				log.Printf("ERROR: locking RBD Image(%s): lock count %i", name, len(lockers))
+				return dkvolume.Response{Err: "Unable to get Exclusive Lock"}
+			}
+
+			// Ok, we have one single valid lock
+			img_locker := lockers[0]
+
+			// Lock is not ours, we will take over
+			// If lock is ours, we will do nothing and continue to try to map
+			// Map os same block device on the same host twice should fail
+
+			if img_locker.id != locker {	
+				err = d.sh_takeOverLock(pool, name, img_locker)
+				if err != nil {
+					log.Printf("ERROR: locking RBD Image(%s): %s", name, err)
+					return dkvolume.Response{Err: "Unable to get Exclusive Lock"}
+				}				
+			}
+
+		} else {
+			log.Printf("ERROR: locking RBD Image(%s): %s", name, err)
+			return dkvolume.Response{Err: "Unable to get Exclusive Lock"}
+		}
 	}
 
 	// map and mount the RBD image -- these are OS level commands, not avail in go-ceph
@@ -786,7 +823,7 @@ func (d *cephRBDVolumeDriver) goceph_rbdImageExists(pool, findName string) (bool
 
 	img := rbd.GetImage(d.ioctx, findName)
 	err := img.Open(true)
-	
+
 	defer img.Close()
 	if err != nil {
 		if err == rbd.RbdErrorNotFound {
@@ -938,7 +975,7 @@ func (d *cephRBDVolumeDriver) sh_lockImage(pool, imagename string) (string, erro
 	cookie := d.localLockerCookie()
 	_, err := d.rbdsh(pool, "lock", "add", imagename, cookie)
 	if err != nil {
-		return "", err
+		return cookie, err
 	}
 	return cookie, nil
 }
@@ -991,26 +1028,36 @@ func (d *cephRBDVolumeDriver) unlockImage(pool, imagename, locker string) error 
 	return d.sh_unlockImage(pool, imagename, locker)
 }
 
-func (d *cephRBDVolumeDriver) sh_unlockImage(pool, imagename, locker string) error {
-	// first - we need to discover the client id of the locker -- so we have to
-	// `rbd lock list` and grep out fields
+func (d *cephRBDVolumeDriver) sh_getImageLocks(pool, imagename string) ([]Lock, error) {
 	out, err := d.rbdsh(pool, "lock", "list", imagename)
-	if err != nil || out == "" {
-		log.Printf("ERROR: image not locked or ceph rbd error: %s", err)
-		return err
+	result := []Lock{}
+
+	if err != nil {
+		log.Printf("ERROR: ceph rbd error: %s", err)
+		return nil, err
 	}
 
-	// parse out client id -- assume we looking for a line with the locker cookie on it --
-	var clientid string
-	lines := grepLines(out, locker)
-	if isDebugEnabled() {
-		log.Printf("DEBUG: found lines matching %s:\n%s\n", locker, lines)
+	lines := regexpLines(out, `^(\S*\.\d+)\s(\S+)\s(\S+\/\d+)$`)
+
+	for _,line := range lines {
+		if isDebugEnabled() {
+			log.Printf("DEBUG: found locker [%s] [%s] [%s]\n", line[1], line[2], line[3])
+		}		
+		result = append(result, Lock{ locker: line[1], id: line[2], address: line[3] })
 	}
-	if len(lines) == 1 {
-		// grab first word of first line as the client.id ?
-		tokens := strings.SplitN(lines[0], " ", 2)
-		if tokens[0] != "" {
-			clientid = tokens[0]
+
+	return result, err
+}
+
+func (d *cephRBDVolumeDriver) sh_unlockImage(pool, imagename, locker string) error {
+	// first - we need to discover the client id of the locker
+	var clientid string
+	lockers, err := d.sh_getImageLocks(pool, imagename)
+	if len(lockers) == 1 {
+		for _,lckr := range lockers {
+			if lckr.id == locker {
+				clientid = lckr.locker
+			}
 		}
 	}
 
@@ -1022,6 +1069,35 @@ func (d *cephRBDVolumeDriver) sh_unlockImage(pool, imagename, locker string) err
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (d *cephRBDVolumeDriver) sh_takeOverLock(pool, imagename string, locker Lock) error {
+	var err error
+	
+	// First we will try to unlock and relock again
+	_, err = d.rbdsh(pool, "lock", "rm", imagename, locker.id, locker.locker)
+	if err != nil {
+		log.Printf("ERROR: can't remove lock from image(%s): %s", imagename, err)
+		return err
+	}
+
+	_, err = d.sh_lockImage(pool, imagename)
+	if err != nil {
+		log.Printf("ERROR: can't relock image(%s): %s", imagename, err)
+		return err
+	}
+
+	// Here WE have the lock, now we need to fence the other locker
+	// If we fail, the lock will be left and we will return error
+	_, err = d.cephsh("osd", "blacklist", "add", locker.address)
+	if err != nil {
+		log.Printf("ERROR: can't blacklist client(%s): %s", locker.address, err)
+		return err
+	}
+
+	// Here we have the lock for us, we can continue
+
 	return nil
 }
 
@@ -1162,4 +1238,10 @@ func (d *cephRBDVolumeDriver) rbdsh(pool, command string, args ...string) (strin
 		args = append([]string{"--pool", pool}, args...)
 	}
 	return shWithDefaultTimeout("rbd", args...)
+}
+
+// cephsh will call ceph with the given command arguments, also adding config and user flags
+func (d *cephRBDVolumeDriver) cephsh(command string, args ...string) (string, error) {
+	args = append([]string{"--conf", d.config, "--id", d.user, command}, args...)
+	return shWithDefaultTimeout("ceph", args...)
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	rootMountDir       = flag.String("mount", dkvolume.DefaultDockerRootDirectory, "Mount directory for volumes on host")
 	logDir             = flag.String("logdir", "/var/log", "Logfile directory")
 	canCreateVolumes   = flag.Bool("create", false, "Can auto Create RBD Images")
+	canOverrideLock    = flag.Bool("override-lock", false, "Can override locks on images using fencing method")
 	defaultImageSizeMB = flag.Int("size", 20*1024, "RBD Image size to Create (in MB) (default: 20480=20GB)")
 	defaultImageFSType = flag.String("fs", "xfs", "FS type for the created RBD Image (must have mkfs.type)")
 	useGoCeph          = flag.Bool("go-ceph", false, "Use go-ceph library (default: false)")

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"regexp"
 )
 
 var (
@@ -81,6 +82,30 @@ func grepLines(data string, like string) []string {
 	}
 	if err := scanner.Err(); err != nil {
 		log.Printf("WARN: error scanning string for %s: %s", like, err)
+	}
+
+	return result
+}
+
+// regexpLines pulls out lines that match a regexp as group matches
+func regexpLines(data string, regexp_s string) [][]string {
+	var result = [][]string{}
+
+  r, err := regexp.Compile(regexp_s)
+  if err != nil {
+      log.Printf("ERROR: unable to compile regexp")
+      return result
+  }
+
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	for scanner.Scan() {
+		s := scanner.Text()
+		if r.MatchString(s) {
+			result = append(result, r.FindStringSubmatch(s))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("WARN: error scanning string for %s: %s", regexp_s, err)
 	}
 
 	return result


### PR DESCRIPTION
I have added option --override-lock
If enabled, when plugin tries to lock the image and fails, it will remove the old lock and blacklists the old lock holder. This is useful when the container is started through marathon or similar - when the slave formerly running the container dies and the container is restarted elsewhere, it can take the lock instead of failing because of stale old lock.

When taking over the lock, the plugin tries to blacklist former lock holder, so if the old container is still running, it can't damage the data.
